### PR TITLE
Date always set to DMY format.

### DIFF
--- a/FoxUnit/Source/fxu.prg
+++ b/FoxUnit/Source/fxu.prg
@@ -59,7 +59,7 @@ SET MULTILOCKS ON
 SET NOTIFY OFF
 SET SAFETY OFF
 SET TALK OFF
-SET DATE TO YMD
+SET DATE TO SHORT			&& -- Alan Bourke Oct 2021 - respect Windows date setting.
 
 *-- FDBOZZO. 06/11/2011. This facilitates automation ("createFxuResultsAddAllTestsAndRun")
 IF NOT EMPTY(tcMethodToAutoRun)


### PR DESCRIPTION
FXU.PRG always sets the date to DMY format. Changed to set to SHORT, i.e. Windows control panel short date setting.